### PR TITLE
Resolved #106. Fixes quoted text.

### DIFF
--- a/src/pronoun-replacement.js
+++ b/src/pronoun-replacement.js
@@ -149,8 +149,8 @@ export function replacePossessiveAdjectives(doc) {
 export function spaceAfterPeriod(text) {
     text = text.replace(/\./g, ". ");
     text = text.replace(/ +/g, " ");
-    text = text.replace(/. "/g, '."');
-    text = text.replace(/. ”/g, ".”");
+    text = text.replace(/\. "/g, '."');
+    text = text.replace(/\. ”/g, ".”");
     return text;
 }
 


### PR DESCRIPTION
Incorrect regex was matching *any* character followed by a space and a quote mark rather than just periods followed by a space and a quote mark.

This was causing an issue where text such as 'she "a"' would end up replaced by 'the."a"' as the regex was matching 'y "' from the temp string 'they "a"' and replacing it with '."'.